### PR TITLE
let Shell know namespace sepatator '\'

### DIFF
--- a/PHP/Shell.php
+++ b/PHP/Shell.php
@@ -312,6 +312,7 @@ class PHP_Shell
                 case T_INT_CAST:
                 case T_STRING_CAST:
                 case T_CURLY_OPEN:
+                case T_NS_SEPARATOR:
 
                     /* just go on */
                     break;


### PR DESCRIPTION
in a PHP_Shell, if i input 

```
Illuminate\Support\Str::ascii('abc')
```

output is

```
unknown tag: 384 (T_NS_SEPARATOR): \  

unknown tag: 384 (T_NS_SEPARATOR): \  

'abc'                                 
```

so i add 'T_NS_SEPARATOR'
